### PR TITLE
Adding HBC and S4C redirects to relevant forms

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,15 @@ const Index = () => (
       <Route path="/consent" component={() => { 
         window.location.href = 'https://forms.gle/Uu21ADNG8Ddznm7DA'; 
         return null;
-      }}/>
+            }} />
+      <Route path="/hbc" component={() => {
+        window.location.href = 'https://forms.gle/sLyqc8vLZdAYhsAh8';
+        return null;
+            }} />
+      <Route path="/s4c" component={() => {
+        window.location.href = 'https://forms.gle/LGJWhhwdfzdz8joW8';
+        return null;
+            }} />
       <Route path="/callback" render={(props) => {
         handleAuthentication(props);
         return <Callback {...props}/>


### PR DESCRIPTION
Should remain in place permanently. At the relevant time, the forms will be updated with note advising the closing date has passed - which can then be removed easily for registration the following year.