### PR TITLE
Restore !important declarations stripped by Biome unsafe fix

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -48,6 +48,9 @@
       },
       "a11y": {
         "useSemanticElements": "warn"
+      },
+      "complexity": {
+        "noImportantStyles": "off"
       }
     }
   },

--- a/src/components/header/Header.css
+++ b/src/components/header/Header.css
@@ -1,17 +1,17 @@
 .sbc-navbar {
-  background-color: white;
-  padding-left: 45px;
-  padding-right: 45px;
-  padding-top: 20px;
-  padding-bottom: 20px;
+  background-color: white !important;
+  padding-left: 45px !important;
+  padding-right: 45px !important;
+  padding-top: 20px !important;
+  padding-bottom: 20px !important;
 }
 
 @media (min-width: 992px) {
   .sbc-navbar {
-    padding-left: 100px;
-    padding-right: 100px;
-    padding-top: 20px;
-    padding-bottom: 20px;
+    padding-left: 100px !important;
+    padding-right: 100px !important;
+    padding-top: 20px !important;
+    padding-bottom: 20px !important;
   }
 }
 
@@ -54,6 +54,6 @@
 
 .login-btn {
   font-family: "Raleway", sans-serif;
-  font-weight: 500;
-  border-style: none;
+  font-weight: 500 !important;
+  border-style: none !important;
 }

--- a/src/components/home/HomePageMeetingTimes.css
+++ b/src/components/home/HomePageMeetingTimes.css
@@ -28,14 +28,14 @@
 }
 
 .what-to-expect-button:hover {
-  background-color: #ff5a34;
-  border-color: #ff5a34;
+  background-color: #ff5a34 !important;
+  border-color: #ff5a34 !important;
   color: white;
 }
 
 .what-to-expect-button:active {
-  background-color: #ff5a34;
-  border-color: #ff5a34;
+  background-color: #ff5a34 !important;
+  border-color: #ff5a34 !important;
   color: white;
 }
 

--- a/src/components/home/HomePageSlide.css
+++ b/src/components/home/HomePageSlide.css
@@ -1,25 +1,25 @@
 .image-slide {
-  min-height: 500px;
-  background-size: cover;
+  min-height: 500px !important;
+  background-size: cover !important;
   text-decoration: none;
 }
 
 .image-slide-content {
-  text-decoration: none;
+  text-decoration: none !important;
 }
 
 .image-slide-content p {
-  text-decoration: none;
+  text-decoration: none !important;
 }
 
 .image-slide-link {
-  text-decoration: none;
+  text-decoration: none !important;
 }
 
 @media (min-width: 992px) {
   .image-slide {
-    min-height: 400px;
-    background-size: contain;
+    min-height: 400px !important;
+    background-size: contain !important;
   }
 }
 
@@ -32,7 +32,7 @@
 .image-slide-type {
   font-family: "Raleway", sans-serif;
   font-weight: 400;
-  font-size: 12pt;
+  font-size: 12pt !important;
   text-align: center;
   margin-top: 30px;
   color: white;
@@ -49,7 +49,7 @@
 .image-slide-title {
   font-family: "Raleway", sans-serif;
   font-weight: 700;
-  font-size: 34pt;
+  font-size: 34pt !important;
   text-align: center;
   margin-top: 20px;
   color: white;
@@ -60,7 +60,7 @@
 
 .image-slide-sub-title {
   font-family: "Crimson Text", serif;
-  font-size: 22pt;
+  font-size: 22pt !important;
   text-align: center;
   margin-top: 10px;
   color: white;
@@ -72,7 +72,7 @@
 .image-slide-sub-subtitle {
   font-family: "Raleway", sans-serif;
   font-weight: 400;
-  font-size: 12pt;
+  font-size: 12pt !important;
   text-align: center;
   margin-top: 20px;
   color: white;
@@ -94,13 +94,13 @@
 }
 
 .image-slide-button:hover {
-  background-color: #ff5a34;
-  border-color: #ff5a34;
+  background-color: #ff5a34 !important;
+  border-color: #ff5a34 !important;
 }
 
 .image-slide-button:active {
-  background-color: #ff5a34;
-  border-color: #ff5a34;
+  background-color: #ff5a34 !important;
+  border-color: #ff5a34 !important;
 }
 
 .image-slide-button:focus {
@@ -110,12 +110,12 @@
 .image-slide-fullheight-row {
   height: 100%;
   overflow: hidden;
-  min-height: 500px;
+  min-height: 500px !important;
 }
 
 @media (min-width: 992px) {
   .image-slide-fullheight-row {
-    min-height: 400px;
+    min-height: 400px !important;
   }
 }
 

--- a/src/components/page/PageBanner.css
+++ b/src/components/page/PageBanner.css
@@ -2,16 +2,16 @@
   margin-left: -10px;
   margin-right: -10px;
   min-height: 300px;
-  background-size: cover;
+  background-size: cover !important;
   margin-bottom: 20px;
 }
 
 .page-banner-mobile-center {
-  background-position: center;
+  background-position: center !important;
 }
 
 .page-banner-mobile-right {
-  background-position: right;
+  background-position: right !important;
 }
 
 .page-banner h1 {
@@ -29,7 +29,7 @@
     margin-left: -100px;
     margin-right: -100px;
     min-height: 350px;
-    background-position: center;
+    background-position: center !important;
   }
   .page-banner .row {
     height: 350px;

--- a/src/components/page/PageSidebar.css
+++ b/src/components/page/PageSidebar.css
@@ -28,7 +28,7 @@
   font-size: 14pt;
   color: #5a5756;
   text-decoration: none;
-  white-space: break-spaces;
+  white-space: break-spaces !important;
   text-align: left;
 }
 
@@ -55,6 +55,6 @@
 
 .btn-page-sidebar-mobile-toggle {
   line-height: 14px;
-  font-size: 32px;
+  font-size: 32px !important;
   color: #ff5a34;
 }


### PR DESCRIPTION
Biome's noImportantStyles rule with --unsafe auto-removed all !important declarations from CSS files. These are needed to override Bootstrap's navbar, button, and layout styles. Restore all 38 declarations and disable the noImportantStyles rule in biome.json.