### PR TITLE
Fix About page sidebar menu color regression

### DIFF
--- a/src/components/page/PageSidebar.css
+++ b/src/components/page/PageSidebar.css
@@ -26,31 +26,31 @@
 .btn-page-sidebar-link {
   font-family: Raleway, serif;
   font-size: 14pt;
-  color: #5a5756;
-  text-decoration: none;
+  color: #5a5756 !important;
+  text-decoration: none !important;
   white-space: break-spaces !important;
   text-align: left;
 }
 
 .btn-page-sidebar-link:hover {
-  color: #ff5a34;
-  text-decoration: none;
+  color: #ff5a34 !important;
+  text-decoration: none !important;
 }
 
 .btn-page-sidebar-link:focus {
-  color: #ff5a34;
-  text-decoration: none;
+  color: #ff5a34 !important;
+  text-decoration: none !important;
 }
 
 .btn-page-sidebar-link:active {
-  color: #ff5a34;
-  text-decoration: none;
+  color: #ff5a34 !important;
+  text-decoration: none !important;
 }
 
 .btn-page-sidebar-link-active {
-  color: #ff5a34;
+  color: #ff5a34 !important;
   font-weight: 500;
-  text-decoration: none;
+  text-decoration: none !important;
 }
 
 .btn-page-sidebar-mobile-toggle {


### PR DESCRIPTION
### Motivation
- Sidebar links on the About page were falling back to the browser/bootstrap blue instead of the intended neutral/orange palette on mobile, so the styles needed stronger overrides to restore the original look.

### Description
- Strengthen the link rules in `src/components/page/PageSidebar.css` by adding `!important` to the `color` and `text-decoration` declarations for `.btn-page-sidebar-link` and its `:hover`, `:focus`, `:active`, and active-item variants so non-active links render gray and active/interactive states render orange as intended.

### Testing
- Ran unit tests with `npm run test` (Vitest) which passed.
- Ran lint with `npm run lint` (Biome) which completed successfully with pre-existing warnings unrelated to this change.
- Started the app with `npm start` and manually validated (via a small Playwright check and screenshots) that the mobile toggle initializes collapsed showing `+` and that menu links render neutral gray with the active link in orange.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5872c50f483248baa0de707ddcac2)